### PR TITLE
Fix Element Snapping Back To Original Position

### DIFF
--- a/projects/ngx-draggable-dom/src/lib/directive/ngx-draggable-dom.directive.ts
+++ b/projects/ngx-draggable-dom/src/lib/directive/ngx-draggable-dom.directive.ts
@@ -616,6 +616,10 @@ export class NgxDraggableDomDirective implements OnInit {
         return;
       }
 
+      // save old start position
+      const prevStartPositionX = this.startPosition.x;
+      const prevStartPositionY = this.startPosition.y;
+
       // compute the current rotation of all parent nodes
       this.computedRotation = NgxDraggableDomUtilities.getTotalRotationForElement(this.el.nativeElement.parentElement);
 
@@ -630,10 +634,6 @@ export class NgxDraggableDomDirective implements OnInit {
       matrix = NgxDraggableDomUtilities.getTransformMatrixForElement(this.el.nativeElement);
       translation.x = matrix[4];
       translation.y = matrix[5];
-
-      // save old start position
-      const prevStartPositionX = this.startPosition.x;
-      const prevStartPositionY = this.startPosition.y;
 
       // translate it back to the start position
       this.startPosition.x -= translation.x;

--- a/projects/ngx-draggable-dom/src/lib/directive/ngx-draggable-dom.directive.ts
+++ b/projects/ngx-draggable-dom/src/lib/directive/ngx-draggable-dom.directive.ts
@@ -631,6 +631,10 @@ export class NgxDraggableDomDirective implements OnInit {
       translation.x = matrix[4];
       translation.y = matrix[5];
 
+      // save old start position
+      const prevStartPositionX = this.startPosition.x;
+      const prevStartPositionY = this.startPosition.y;
+
       // translate it back to the start position
       this.startPosition.x -= translation.x;
       this.startPosition.y -= translation.y;
@@ -643,8 +647,8 @@ export class NgxDraggableDomDirective implements OnInit {
       );
 
       // calculate the offset position of the mouse compared to the element center
-      this.pickUpOffset.x = this.scrollLeft + event.clientX - this.startPosition.x;
-      this.pickUpOffset.y = this.scrollTop + event.clientY - this.startPosition.y;
+      this.pickUpOffset.x = this.scrollLeft + event.clientX - prevStartPositionX;
+      this.pickUpOffset.y = this.scrollTop + event.clientY - prevStartPositionY;
 
       // fire the event to signal that the element has begun moving
       this.started.emit(new NgxDraggableDomMoveEvent(this.el.nativeElement as HTMLElement, translation));


### PR DESCRIPTION
The element will shift back to the original position while attempting to drag after the putBack event fires for the first time. Using the startPosition to calculate the pickUpOffset seems to be the cause of this because your pickUpOffset is now relative to the original startPosition and not the current startPosition. Using the original start position before any rotations or transformations are applied seems to fix this. 